### PR TITLE
added correct path on rockpi and also filling out with 0s too match buffers

### DIFF
--- a/hosted/examples/graphing.rs
+++ b/hosted/examples/graphing.rs
@@ -42,7 +42,7 @@ impl MockSpi {
         measurement_writer: MeasurementWriter,
         reference_reader: CommitReader,
     ) -> Option<Vec<JoinHandle<()>>> {
-        let spi = Spi::init("/dev/spidev0.0")?;
+        let spi = Spi::init("/dev/spidev1.0")?;
 
         let ret = Arc::new(Mutex::new(MockSpi {
             target_value: 0.,

--- a/hosted/src/spi.rs
+++ b/hosted/src/spi.rs
@@ -73,7 +73,7 @@ impl<V: Version<BusItem = u8>> Spi<V> {
     {
         let target: Vec<u8> = Message::<V>::new(payload).collect();
         // Make a really large buffer, this is a "fulhack" but it is fine for now.
-        let mut rx_buff = [0; 1024];
+        let mut rx_buff: Vec<u8>  = target.iter().map(|_| 0).collect();
 
         let mut xfer = spi_ioc_transfer::read_write(target.as_slice(), &mut rx_buff);
         self.spi.transfer(&mut xfer).map_err(Error::IoError)?;

--- a/hosted/src/spi.rs
+++ b/hosted/src/spi.rs
@@ -73,7 +73,7 @@ impl<V: Version<BusItem = u8>> Spi<V> {
     {
         let target: Vec<u8> = Message::<V>::new(payload).collect();
         // Make a really large buffer, this is a "fulhack" but it is fine for now.
-        let mut rx_buff: Vec<u8>  = target.iter().map(|_| 0).collect();
+        let mut rx_buff: Vec<u8> = target.iter().map(|_| 0).collect();
 
         let mut xfer = spi_ioc_transfer::read_write(target.as_slice(), &mut rx_buff);
         self.spi.transfer(&mut xfer).map_err(Error::IoError)?;


### PR DESCRIPTION
sets a new path on Mock:spi to the correct path on the rockPi, also filling out buffers with 0s to be the same size if they aren't